### PR TITLE
Sync mapping manager

### DIFF
--- a/.github/workflows/client5.yml
+++ b/.github/workflows/client5.yml
@@ -31,7 +31,7 @@ jobs:
         pip install --upgrade setuptools pip flit codecov
         pip install --upgrade git+https://github.com/jupyter/jupyter_client.git@987f3e1de21e34d7f6f8b3225a6b044e1bdb0152
         flit install
-        pip install "jupyter_client<6" "jupyter_server<0.3"
+        pip install "jupyter_client<6" "jupyter_server<0.3" pytest_tornasync
     - name: Run the tests
       run: py.test --cov hotpot_km -v -s --log-cli-level=DEBUG -k _sync
     - name: Code coverage

--- a/.github/workflows/client5.yml
+++ b/.github/workflows/client5.yml
@@ -31,7 +31,7 @@ jobs:
         pip install --upgrade setuptools pip flit codecov
         pip install --upgrade git+https://github.com/jupyter/jupyter_client.git@987f3e1de21e34d7f6f8b3225a6b044e1bdb0152
         flit install
-        pip install "jupyter_client<6"
+        pip install "jupyter_client<6" "jupyter_server<0.3"
     - name: Run the tests
       run: py.test --cov hotpot_km -v -s --log-cli-level=DEBUG -k _sync
     - name: Code coverage

--- a/hotpot_km/async_utils.py
+++ b/hotpot_km/async_utils.py
@@ -45,6 +45,8 @@ def check_patch_tornado() -> None:
 
 def just_run(coro: Awaitable) -> Any:
     """Make the coroutine run, even if there is an event loop running (using nest_asyncio)"""
+    if not inspect.isawaitable(coro):
+        return coro
     # original from vaex/asyncio.py
     loop = asyncio._get_running_loop()
     if loop is None:

--- a/hotpot_km/limited.py
+++ b/hotpot_km/limited.py
@@ -25,7 +25,7 @@ class SyncLimitedKernelManager(MultiKernelManager):
         if "kernel_id" not in kwargs and len(self) >= self.max_kernels > 0:
             self.log.debug("Refusing to start kernel, maximum number reached.")
             raise MaximumKernelsException("No kernels are available.")
-        return super().start_kernel(kernel_name, **kwargs)
+        return super().start_kernel(kernel_name=kernel_name, **kwargs)
 
 
 __all__ = [

--- a/hotpot_km/mapping_sync.py
+++ b/hotpot_km/mapping_sync.py
@@ -1,0 +1,14 @@
+
+from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+
+from .pooled_sync import SyncPooledKernelManager
+
+
+class SyncPooledMappingKernelManager(
+    SyncPooledKernelManager,
+    MappingKernelManager
+):
+    def restart_kernel(self, kernel_id, **kwargs):
+        if kwargs:
+            self.log.warning("Ignored arguments to restart_kernel: %r", kwargs)
+        return super().restart_kernel(kernel_id)

--- a/hotpot_km/pooled_sync.py
+++ b/hotpot_km/pooled_sync.py
@@ -110,7 +110,7 @@ class SyncPooledKernelManager(SyncLimitedKernelManager):
             self._pools[name] = pool
             for i in range(target - len(pool)):
                 kw = self.pool_kwargs.get(name, {})
-                kernel_id = super().start_kernel(kernel_name=name, **kw)
+                kernel_id = just_run(super().start_kernel(kernel_name=name, **kw))
                 # Todo: use delay
                 # Start the work on the loop immediately, so it is ready when needed:
                 self._init_futs[kernel_id] = loop.create_task(self._initialize(name, kernel_id))
@@ -133,7 +133,7 @@ class SyncPooledKernelManager(SyncLimitedKernelManager):
         if kernel_id is None and self._should_use_pool(kernel_name, kwargs):
             kernel_id = just_run(self._pop_pooled_kernel(kernel_name, kwargs))
         else:
-            kernel_id = super().start_kernel(kernel_name=kernel_name, **kwargs)
+            kernel_id = just_run(super().start_kernel(kernel_name=kernel_name, **kwargs))
 
         try:
             self.fill_if_needed()
@@ -144,7 +144,7 @@ class SyncPooledKernelManager(SyncLimitedKernelManager):
     def restart_kernel(self, kernel_id, **kwargs):
         km = self.get_kernel(kernel_id)
         kernel_name = km.kernel_name
-        super().restart_kernel(kernel_id, **kwargs)
+        just_run(super().restart_kernel(kernel_id, **kwargs))
         just_run(self._update_kernel(kernel_name, kernel_id, km._launch_args))
         just_run(self._initialize(kernel_name, kernel_id))
 

--- a/hotpot_km/tests/test_mapping_sync.py
+++ b/hotpot_km/tests/test_mapping_sync.py
@@ -9,7 +9,7 @@ from tornado.testing import gen_test
 
 from .. import MaximumKernelsException
 try:
-    from ..mapping import PooledMappingKernelManager
+    from ..mapping_sync import SyncPooledMappingKernelManager
 except ImportError:
     pass
 
@@ -26,7 +26,7 @@ class TestSyncMappingKernelManagerUnused(TestAsyncKernelManager):
     @asynccontextmanager
     async def _get_tcp_km():
         c = Config()
-        km = PooledMappingKernelManager(config=c)
+        km = SyncPooledMappingKernelManager(config=c)
         try:
             yield km
         finally:
@@ -48,11 +48,11 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
     @asynccontextmanager
     async def _get_tcp_km():
         c = Config()
-        c.LimitedKernelManager.max_kernels = 4
-        c.PooledMappingKernelManager.fill_delay = 0
-        c.PooledMappingKernelManager.kernel_pools = {NATIVE_KERNEL_NAME: 2}
-        c.PooledMappingKernelManager.pool_kwargs = {NATIVE_KERNEL_NAME: dict(stdout=PIPE, stderr=PIPE)}
-        km = PooledMappingKernelManager(config=c)
+        c.SyncLimitedKernelManager.max_kernels = 4
+        c.SyncPooledMappingKernelManager.fill_delay = 0
+        c.SyncPooledMappingKernelManager.kernel_pools = {NATIVE_KERNEL_NAME: 2}
+        c.SyncPooledMappingKernelManager.pool_kwargs = {NATIVE_KERNEL_NAME: dict(stdout=PIPE, stderr=PIPE)}
+        km = SyncPooledMappingKernelManager(config=c)
         try:
             yield km
         finally:
@@ -73,7 +73,6 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
                 kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
                 self.assertIn(kid, km)
                 kids.append(kid)
-                self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
 
             await async_shutdown_all_direct(km)
             for kid in kids:
@@ -85,7 +84,6 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
                 kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
                 self.assertIn(kid, km)
                 kids.append(kid)
-                self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
 
             await ensure_async(km.shutdown_all())
             for kid in kids:

--- a/hotpot_km/tests/test_mapping_sync.py
+++ b/hotpot_km/tests/test_mapping_sync.py
@@ -1,0 +1,117 @@
+
+from contextlib import asynccontextmanager
+from subprocess import PIPE
+
+from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
+from pytest import mark
+from traitlets.config.loader import Config
+from tornado.testing import gen_test
+
+from .. import MaximumKernelsException
+try:
+    from ..mapping import PooledMappingKernelManager
+except ImportError:
+    pass
+
+from..async_utils import ensure_async
+from .utils import async_shutdown_all_direct, TestAsyncKernelManager
+
+
+# Test that it works as normal with default config
+class TestSyncMappingKernelManagerUnused(TestAsyncKernelManager):
+    __test__ = True
+
+    # static so picklable for multiprocessing on Windows
+    @staticmethod
+    @asynccontextmanager
+    async def _get_tcp_km():
+        c = Config()
+        km = PooledMappingKernelManager(config=c)
+        try:
+            yield km
+        finally:
+            await ensure_async(km.shutdown_all())
+
+    # Mapping manager doesn't handle this:
+    @mark.skip()
+    @gen_test
+    async def test_tcp_lifecycle_with_kernel_id(self):
+        pass
+
+
+# Test that it works with a max that is larger than pool size
+class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
+    __test__ = True
+
+    # static so picklable for multiprocessing on Windows
+    @staticmethod
+    @asynccontextmanager
+    async def _get_tcp_km():
+        c = Config()
+        c.LimitedKernelManager.max_kernels = 4
+        c.PooledMappingKernelManager.fill_delay = 0
+        c.PooledMappingKernelManager.kernel_pools = {NATIVE_KERNEL_NAME: 2}
+        c.PooledMappingKernelManager.pool_kwargs = {NATIVE_KERNEL_NAME: dict(stdout=PIPE, stderr=PIPE)}
+        km = PooledMappingKernelManager(config=c)
+        try:
+            yield km
+        finally:
+            await ensure_async(km.shutdown_all())
+
+    # Mapping manager doesn't handle this:
+    @mark.skip()
+    @gen_test
+    async def test_tcp_lifecycle_with_kernel_id(self):
+        pass
+
+    @gen_test(timeout=60)
+    async def test_exceed_pool_size(self):
+        async with self._get_tcp_km() as km:
+            self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
+            kids = []
+            for i in range(4):
+                kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+                self.assertIn(kid, km)
+                kids.append(kid)
+                self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
+
+            await async_shutdown_all_direct(km)
+            for kid in kids:
+                self.assertNotIn(kid, km)
+
+            # Cycle again to assure the pool survives that
+            kids = []
+            for i in range(4):
+                kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+                self.assertIn(kid, km)
+                kids.append(kid)
+                self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
+
+            await ensure_async(km.shutdown_all())
+            for kid in kids:
+                self.assertNotIn(kid, km)
+
+    @gen_test(timeout=60)
+    async def test_breach_max(self):
+        async with self._get_tcp_km() as km:
+            kids = []
+            for i in range(4):
+                kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+                self.assertIn(kid, km)
+                kids.append(kid)
+
+            with self.assertRaises(MaximumKernelsException):
+                await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+
+            # Remove and add one to make sure we correctly recovered
+            await ensure_async(km.shutdown_kernel(kid))
+            self.assertNotIn(kid, km)
+            kids.pop()
+
+            kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+            self.assertIn(kid, km)
+            kids.append(kid)
+
+            await ensure_async(km.shutdown_all())
+            for kid in kids:
+                self.assertNotIn(kid, km)

--- a/hotpot_km/tests/test_mapping_sync.py
+++ b/hotpot_km/tests/test_mapping_sync.py
@@ -10,8 +10,8 @@ from tornado.testing import gen_test
 from .. import MaximumKernelsException
 try:
     from ..mapping_sync import SyncPooledMappingKernelManager
-except ImportError:
-    pass
+except ImportError as e:
+    print(f"Won't be able to test synced pool: {e}")
 
 from..async_utils import ensure_async
 from .utils import async_shutdown_all_direct, TestAsyncKernelManager

--- a/hotpot_km/tests/test_pooled_manager_sync.py
+++ b/hotpot_km/tests/test_pooled_manager_sync.py
@@ -1,5 +1,4 @@
 
-import asyncio
 from contextlib import contextmanager
 from subprocess import PIPE
 from unittest import TestCase
@@ -12,11 +11,11 @@ from .. import (
     SyncPooledKernelManager,
     MaximumKernelsException,
 )
-
 from .utils_sync import shutdown_all_direct, TestKernelManager
 
+
 # Test that it works as normal with default config
-class TestPooledKernelManagerUnused(TestKernelManager):
+class TestSyncPooledKernelManagerUnused(TestKernelManager):
     __test__ = True
 
     # static so picklable for multiprocessing on Windows
@@ -32,7 +31,7 @@ class TestPooledKernelManagerUnused(TestKernelManager):
 
 
 # Test that it works with an unstrict pool
-class TestPooledKernelManagerApplied(TestKernelManager):
+class TestSyncPooledKernelManagerApplied(TestKernelManager):
     __test__ = True
 
     # static so picklable for multiprocessing on Windows
@@ -48,7 +47,7 @@ class TestPooledKernelManagerApplied(TestKernelManager):
         try:
             yield km
         finally:
-            km.shutdown_all()
+            km.shutdown_all(now=True)
 
     def test_exceed_pool_size(self):
         with self._get_tcp_km() as km:
@@ -78,8 +77,6 @@ class TestPooledKernelManagerApplied(TestKernelManager):
         with self._get_tcp_km() as km:
             km.kernel_pools = {NATIVE_KERNEL_NAME: 1}
             self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 1)
-            # km.shutdown_kernel is not reentrant, so await:
-            asyncio.gather(*km._discarded)
 
     def test_increase_pool_size(self):
         with self._get_tcp_km() as km:
@@ -113,9 +110,8 @@ class TestPooledKernelManagerApplied(TestKernelManager):
             km.shutdown_all()
 
 
-
 # Test that it works with an strict pool
-class TestPooledKernelManagerStrict(TestCase):
+class TestSyncPooledKernelManagerStrict(TestCase):
 
     def test_strict_name_correct(self):
         c = Config()

--- a/hotpot_km/tests/test_update.py
+++ b/hotpot_km/tests/test_update.py
@@ -89,7 +89,7 @@ class TestUpdatePooled(AsyncTestCase):
                 async with client.setup_kernel():
                     await client.execute('import foo_module\nprint(foo_module.__file__)')
                 self.assertEqual(client._outputs, [{
-                    'name': 'stdout', 'output_type': 'stream', 'text': f'{foo_mod}\n'
+                    'name': 'stdout', 'output_type': 'stream', 'text': f'{foo_mod.resolve()}\n'
                 }])
             finally:
                 await km.shutdown_all()

--- a/hotpot_km/tests/test_update.py
+++ b/hotpot_km/tests/test_update.py
@@ -87,7 +87,7 @@ class TestUpdatePooled(AsyncTestCase):
 
                 client = ExecClient(kernel, _store_outputs=True)
                 async with client.setup_kernel():
-                    await client.execute('import foo_module\nprint(foo_module.__file__)')
+                    await client.execute('import foo_module, pathlib\nprint(pathlib.Path(foo_module.__file__).resolve())')
                 self.assertEqual(client._outputs, [{
                     'name': 'stdout', 'output_type': 'stream', 'text': f'{foo_mod.resolve()}\n'
                 }])

--- a/hotpot_km/tests/utils.py
+++ b/hotpot_km/tests/utils.py
@@ -11,7 +11,6 @@ from unittest import TestCase
 
 from jupyter_client import KernelManager
 from jupyter_client.ioloop import IOLoopKernelManager
-from jupyter_client.tests.utils import skip_win32
 from jupyter_client.localinterfaces import localhost
 
 from ..async_utils import ensure_async
@@ -140,6 +139,7 @@ class TestAsyncKernelManager(AsyncTestCase):
             thread.join()
             thread2.join()
 
+    @pytest.mark.skipif(sys.platform.startswith('linux'), reason="Linux")
     @gen_test
     async def test_start_parallel_process_kernels(self):
         await self.raw_tcp_lifecycle()

--- a/hotpot_km/tests/utils.py
+++ b/hotpot_km/tests/utils.py
@@ -25,7 +25,7 @@ async def async_shutdown_all_direct(km):
     kids = km.list_kernel_ids()
     futs = []
     for kid in kids:
-        await km.shutdown_kernel(kid)
+        await ensure_async(km.shutdown_kernel(kid))
 
 
 class TestAsyncKernelManager(AsyncTestCase):
@@ -36,24 +36,24 @@ class TestAsyncKernelManager(AsyncTestCase):
     @staticmethod
     async def _run_lifecycle(km, test_kid=None):
         if test_kid:
-            kid = await km.start_kernel(stdout=PIPE, stderr=PIPE, kernel_id=test_kid)
+            kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE, kernel_id=test_kid))
             assert kid == test_kid
         else:
-            kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
-        assert await km.is_alive(kid)
+            kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+        assert await ensure_async(km.is_alive(kid))
         assert kid in km
         assert kid in km.list_kernel_ids()
-        await km.restart_kernel(kid, now=True)
-        assert await km.is_alive(kid)
+        await ensure_async(km.restart_kernel(kid, now=True))
+        assert await ensure_async(km.is_alive(kid))
         assert kid in km.list_kernel_ids()
-        await km.interrupt_kernel(kid)
+        await ensure_async(km.interrupt_kernel(kid))
         k = km.get_kernel(kid)
         assert isinstance(k, KernelManager)
-        await km.shutdown_kernel(kid, now=True)
+        await ensure_async(km.shutdown_kernel(kid, now=True))
         assert kid not in km, f'{kid} not in {km}'
 
     async def _run_cinfo(self, km, transport, ip):
-        kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
+        kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
         k = km.get_kernel(kid)
         cinfo = km.get_connection_info(kid)
         self.assertEqual(transport, cinfo['transport'])
@@ -82,7 +82,7 @@ class TestAsyncKernelManager(AsyncTestCase):
     @gen_test(timeout=20)
     async def test_shutdown_all(self):
         async with self._get_tcp_km() as km:
-            kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
+            kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
             self.assertIn(kid, km)
             await ensure_async(km.shutdown_all())
             self.assertNotIn(kid, km)

--- a/hotpot_km/tests/utils.py
+++ b/hotpot_km/tests/utils.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import sys
 import threading
 import uuid
 import multiprocessing as mp

--- a/hotpot_km/tests/utils.py
+++ b/hotpot_km/tests/utils.py
@@ -1,6 +1,5 @@
 
 import asyncio
-import sys
 import threading
 import uuid
 import multiprocessing as mp
@@ -140,7 +139,7 @@ class TestAsyncKernelManager(AsyncTestCase):
             thread.join()
             thread2.join()
 
-    @pytest.mark.skipif(sys.platform.startswith('linux'), reason="Linux")
+    @pytest.mark.skipif(mp.get_start_method() == "fork", reason="Fork")
     @gen_test
     async def test_start_parallel_process_kernels(self):
         await self.raw_tcp_lifecycle()

--- a/hotpot_km/tests/utils_sync.py
+++ b/hotpot_km/tests/utils_sync.py
@@ -1,6 +1,5 @@
 
 import asyncio
-import sys
 import threading
 import uuid
 import multiprocessing as mp
@@ -120,7 +119,7 @@ class TestKernelManager(TestCase):
             thread.join()
             thread2.join()
 
-    @pytest.mark.skipif(sys.platform.startswith('linux'), reason="Linux")
+    @pytest.mark.skipif(mp.get_start_method() == "fork", reason="Fork")
     def test_start_parallel_process_kernels(self):
         self.raw_tcp_lifecycle()
 

--- a/hotpot_km/tests/utils_sync.py
+++ b/hotpot_km/tests/utils_sync.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import sys
 import threading
 import uuid
 import multiprocessing as mp

--- a/hotpot_km/tests/utils_sync.py
+++ b/hotpot_km/tests/utils_sync.py
@@ -119,6 +119,7 @@ class TestKernelManager(TestCase):
             thread.join()
             thread2.join()
 
+    @pytest.mark.skipif(sys.platform.startswith('linux'), reason="Linux")
     def test_start_parallel_process_kernels(self):
         self.raw_tcp_lifecycle()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ test = [
     "jupyter_server",
     "jupyter_client[test]",
 ]
+mapping=[
+    "jupyter_server",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ requires = [
     "async_generator",
     "jupyter_client",
     "nbformat",
+    "nest_asyncio",
     "traitlets",
 ]
 


### PR DESCRIPTION
Also fixes and enables parallel tests when multiprocessing is done using "spawn". Fixing "fork" mp is for another day.