### PR TITLE
Don't cull pool kernels + various fixes

### DIFF
--- a/hotpot_km/mapping.py
+++ b/hotpot_km/mapping.py
@@ -1,5 +1,6 @@
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 
+from .limited import MaximumKernelsException
 from .pooled import PooledKernelManager
 
 
@@ -8,3 +9,17 @@ class PooledMappingKernelManager(PooledKernelManager, AsyncMappingKernelManager)
         if kwargs:
             self.log.warning("Ignored arguments to restart_kernel: %r", kwargs)
         return await super().restart_kernel(kernel_id)
+
+    async def cull_kernel_if_idle(self, kernel_id):
+        # Ensure we don't cull pooled kernels:
+        # (this logic assumes the init time is shorter than the cull time)
+        for pool in self._pools.values():
+            for i, f in enumerate(pool):
+                try:
+                    if f.done() and f.result() == kernel_id:
+                        return
+                except Exception as e:
+                    if not isinstance(e, MaximumKernelsException):
+                        self.log.exception("Kernel failed starting up")
+                    pool.pop(i)
+        return await super().cull_kernel_if_idle(kernel_id)

--- a/hotpot_km/mapping_sync.py
+++ b/hotpot_km/mapping_sync.py
@@ -1,3 +1,6 @@
+
+import asyncio
+
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 
 from .pooled_sync import SyncPooledKernelManager
@@ -8,3 +11,18 @@ class SyncPooledMappingKernelManager(SyncPooledKernelManager, MappingKernelManag
         if kwargs:
             self.log.warning("Ignored arguments to restart_kernel: %r", kwargs)
         return super().restart_kernel(kernel_id)
+
+    if asyncio.iscoroutinefunction(MappingKernelManager.cull_kernel_if_idle):
+        async def cull_kernel_if_idle(self, kernel_id):
+            # Ensure we don't cull pooled kernels:
+            for pool in self._pools.values():
+                if kernel_id in pool:
+                    return
+            return await super().cull_kernel_if_idle(kernel_id)
+    else:
+        def cull_kernel_if_idle(self, kernel_id):
+            # Ensure we don't cull pooled kernels:
+            for pool in self._pools.values():
+                if kernel_id in pool:
+                    return
+            return super().cull_kernel_if_idle(kernel_id)

--- a/hotpot_km/pooled.py
+++ b/hotpot_km/pooled.py
@@ -116,7 +116,7 @@ class PooledKernelManager(LimitedKernelManager):
 
     async def wait_for_pool(self):
         all_tasks = []
-        for name, pool in self._pools.items():
+        for pool in self._pools.values():
             all_tasks.extend(pool)
         await asyncio.gather(*all_tasks)
 
@@ -150,26 +150,27 @@ class PooledKernelManager(LimitedKernelManager):
         await self._initialize(kernel_name, id_future)
 
     async def shutdown_kernel(self, kernel_id, *args, **kwargs):
-        if kernel_id not in self._kernels:
-            for pool in self._pools.values():
-                for i, f in enumerate(pool):
-                    try:
-                        if f.done() and f.result() == kernel_id:
-                            pool.pop(i)
-                            break
-                    except Exception as e:
-                        if not isinstance(e, MaximumKernelsException):
-                            self.log.exception("Kernel failed starting up")
+        for pool in self._pools.values():
+            for i, f in enumerate(pool):
+                try:
+                    if f.done() and f.result() == kernel_id:
                         pool.pop(i)
-                else:
-                    continue
-                break
+                        break
+                except Exception as e:
+                    if not isinstance(e, MaximumKernelsException):
+                        self.log.exception("Kernel failed starting up")
+                    pool.pop(i)
+            else:
+                continue
+            break
         return await super().shutdown_kernel(kernel_id, *args, **kwargs)
 
     async def shutdown_all(self, *args, **kwargs):
         await super().shutdown_all(*args, **kwargs)
         # Parent doesn't correctly add all created kernels until they have completed startup:
-        for pool in self._pools.values():
+        pools = self._pools
+        self._pools = {}
+        for pool in pools.values():
             # The iteration gets confused if we don't copy pool
             for fut in tuple(pool):
                 try:
@@ -185,7 +186,6 @@ class PooledKernelManager(LimitedKernelManager):
         except Exception as e:
             if not isinstance(e, MaximumKernelsException):
                 self.log.exception("Kernel failed starting up")
-        self._pools = {}
         self._discarded = []
 
     async def _update_kernel(self, kernel_name, kernel_id_future, kwargs):

--- a/hotpot_km/pooled.py
+++ b/hotpot_km/pooled.py
@@ -12,7 +12,7 @@ import asyncio
 from traitlets import Bool, Dict, Float, Integer, List, Unicode, observe
 
 from .async_utils import await_then_kill, ensure_event_loop, wait_before
-from .client_helper import ExecClient
+from .client_helper import ExecClient, DeadKernelError
 from .limited import LimitedKernelManager, MaximumKernelsException
 from .py_snippets import (
     python_update_cwd_code,
@@ -132,7 +132,7 @@ class PooledKernelManager(LimitedKernelManager):
         while kernel_id is None and self._should_use_pool(kernel_name, kwargs):
             try:
                 kernel_id = await self._pop_pooled_kernel(kernel_name, kwargs)
-            except MaximumKernelsException:
+            except (MaximumKernelsException, DeadKernelError):
                 pass
         if kernel_id is None or kwargs.get("kernel_id") is not None:
             kernel_id = await super().start_kernel(kernel_name=kernel_name, **kwargs)

--- a/hotpot_km/tests/test_mapping.py
+++ b/hotpot_km/tests/test_mapping.py
@@ -1,9 +1,13 @@
+import asyncio
 from contextlib import asynccontextmanager
+import platform
 from subprocess import PIPE
+
 
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 from pytest import mark
 from traitlets.config.loader import Config
+from tornado.web import HTTPError
 from tornado.testing import gen_test
 
 from .. import MaximumKernelsException
@@ -15,6 +19,11 @@ except ImportError:
 
 
 from .utils import async_shutdown_all_direct, TestAsyncKernelManager
+
+
+CULL_TIMEOUT = 10 if platform.python_implementation() == 'PyPy' else 5
+CULL_INTERVAL = 1
+
 
 # Test that it works as normal with default config
 class TestMappingKernelManagerUnused(TestAsyncKernelManager):
@@ -45,7 +54,7 @@ class TestMappingKernelManagerApplied(TestAsyncKernelManager):
     # static so picklable for multiprocessing on Windows
     @staticmethod
     @asynccontextmanager
-    async def _get_tcp_km():
+    async def _get_tcp_km(config_culling=False):
         c = Config()
         c.LimitedKernelManager.max_kernels = 4
         c.PooledMappingKernelManager.fill_delay = 0
@@ -53,6 +62,11 @@ class TestMappingKernelManagerApplied(TestAsyncKernelManager):
         c.PooledMappingKernelManager.pool_kwargs = {
             NATIVE_KERNEL_NAME: dict(stdout=PIPE, stderr=PIPE)
         }
+        if config_culling:
+            c.MappingKernelManager.cull_idle_timeout = CULL_TIMEOUT
+            c.MappingKernelManager.cull_interval = CULL_INTERVAL
+            c.MappingKernelManager.cull_connected = False
+
         km = PooledMappingKernelManager(config=c)
         try:
             await km.wait_for_pool()
@@ -117,3 +131,36 @@ class TestMappingKernelManagerApplied(TestAsyncKernelManager):
             await km.shutdown_all()
             for kid in kids:
                 self.assertNotIn(kid, km)
+
+    @gen_test(timeout=60)
+    async def test_culling(self):
+        # this will start and await the pool:
+        async with self._get_tcp_km(config_culling=True) as km:
+            self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
+            self.assertEqual(len(km), 2)
+
+            kid = await km._pools[NATIVE_KERNEL_NAME][0]
+
+            culled = await self.get_cull_status(km, kid)  # in pool, should not be culled
+            assert not culled
+
+            # pop one kernel
+            kid = await km.start_kernel(stdout=PIPE, stderr=PIPE)
+
+            culled = await self.get_cull_status(km, kid)  # now active, should be culled
+            assert culled
+
+
+    async def get_cull_status(self, km, kid):
+        frequency = 0.5
+        culled = False
+        for _ in range(int((CULL_TIMEOUT + CULL_INTERVAL)/frequency)):  # Timeout + Interval will ensure cull
+            try:
+                km.get_kernel(kid)
+            except HTTPError as e:
+                assert e.status_code == 404
+                culled = True
+                break
+            else:
+                await asyncio.sleep(frequency)
+        return culled

--- a/hotpot_km/tests/test_mapping_sync.py
+++ b/hotpot_km/tests/test_mapping_sync.py
@@ -1,10 +1,13 @@
+import asyncio
 from contextlib import asynccontextmanager
+import platform
 from subprocess import PIPE
 
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 from pytest import mark
 from traitlets.config.loader import Config
-from tornado.testing import gen_test
+from tornado.web import HTTPError
+from tornado.testing import gen_test, AsyncTestCase
 
 from .. import MaximumKernelsException
 
@@ -15,6 +18,10 @@ except ImportError as e:
 
 from ..async_utils import ensure_async
 from .utils import async_shutdown_all_direct, TestAsyncKernelManager
+
+
+CULL_TIMEOUT = 10 if platform.python_implementation() == 'PyPy' else 5
+CULL_INTERVAL = 1
 
 
 # Test that it works as normal with default config
@@ -46,7 +53,7 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
     # static so picklable for multiprocessing on Windows
     @staticmethod
     @asynccontextmanager
-    async def _get_tcp_km():
+    async def _get_tcp_km(config_culling=False):
         c = Config()
         c.SyncLimitedKernelManager.max_kernels = 4
         c.SyncPooledMappingKernelManager.fill_delay = 0
@@ -54,6 +61,10 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
         c.SyncPooledMappingKernelManager.pool_kwargs = {
             NATIVE_KERNEL_NAME: dict(stdout=PIPE, stderr=PIPE)
         }
+        if config_culling:
+            c.MappingKernelManager.cull_idle_timeout = CULL_TIMEOUT
+            c.MappingKernelManager.cull_interval = CULL_INTERVAL
+            c.MappingKernelManager.cull_connected = False
         km = SyncPooledMappingKernelManager(config=c)
         try:
             yield km
@@ -115,3 +126,36 @@ class TestSyncMappingKernelManagerApplied(TestAsyncKernelManager):
             await ensure_async(km.shutdown_all())
             for kid in kids:
                 self.assertNotIn(kid, km)
+
+    @gen_test(timeout=60)
+    async def test_culling(self):
+        # this will start and await the pool:
+        async with self._get_tcp_km(config_culling=True) as km:
+            self.assertEqual(len(km._pools[NATIVE_KERNEL_NAME]), 2)
+            self.assertEqual(len(km), 2)
+
+            kid = km._pools[NATIVE_KERNEL_NAME][0]
+
+            culled = await self.get_cull_status(km, kid)  # in pool, should not be culled
+            assert not culled
+
+            # pop one kernel
+            kid = await ensure_async(km.start_kernel(stdout=PIPE, stderr=PIPE))
+
+            culled = await self.get_cull_status(km, kid)  # now active, should be culled
+            assert culled
+
+
+    async def get_cull_status(self, km, kid):
+        frequency = 0.5
+        culled = False
+        for _ in range(int((CULL_TIMEOUT + CULL_INTERVAL)/frequency)):  # Timeout + Interval will ensure cull
+            try:
+                km.get_kernel(kid)
+            except HTTPError as e:
+                assert e.status_code == 404
+                culled = True
+                break
+            else:
+                await asyncio.sleep(frequency)
+        return culled


### PR DESCRIPTION
This PR:
- Adds logic to prevent kernels in the pool from being culled + tests for the same.
- Improves some error handling in various cases, especially if a kernel dies or gets shut down during init.
- Improves pool bookkeeping for `shutdown_kernel`/`shutdown_all`.
- Various other fixes, see commit messages for details.